### PR TITLE
Add parameters to install more dependencies on seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,19 +14,33 @@ npm install -g @msg-labs/ts-seed
 ## Usage
 
 ```
-  Usage: ts-seed [options] [name]
 
-  Generate a new project using the specified name
+  Usage: ts-seed [options] <name>
 
   Options:
 
-    -h, --help     output usage information
-    -V, --version  output the version number
+    -h, --help        output usage information
+    -V, --version     output the version number
+    -d, --prod <dep>  Dependencies to install along the default ones
+    -D, --dev <dep>   Development dependencies to install along the default ones
+
 ```
+
+## Multiple dependencies
+
+To add multiple dependencies of any kind of type just add more switches
+
+```
+ts-seed my-project -d pug -d lodash -D mocha
+```
+
+Will install ```pug``` and ```lodash``` as dependencies and ```mocha``` as
+devDependency
 
 ## The structure
 
 ```
+
 [name]
 |-- LICENSE
 |-- README.md
@@ -36,6 +50,7 @@ npm install -g @msg-labs/ts-seed
 |   `-- index.ts
 |-- tsconfig.json
 `-- webpack.config.js
+
 ```
 
 ## Licensing

--- a/bin/ts-seed.js
+++ b/bin/ts-seed.js
@@ -1,17 +1,24 @@
 #!/usr/bin/env node
 
 const program = require( 'commander' );
-const { version } = require( '../package.json' );
 
+const { version } = require( '../package.json' );
 const generate = require( '../src/new' );
+
+
+const deps = ( dependency, dependencies ) => ( [
+    ...dependencies,
+    dependency
+] );
 
 
 program
     .version( version );
 
 program
-    .arguments( '[name]' )
-    .description( 'Generate a new project using the specified name' )
+    .usage( '[options] <name>' )
+    .option( '-d, --prod <dep>', 'Dependencies to install along the default ones', deps, [] )
+    .option( '-D, --dev <dep>', 'Development dependencies to install along the default ones', deps, [] )
     .action( generate );
 
 program

--- a/src/install/utils.js
+++ b/src/install/utils.js
@@ -1,0 +1,25 @@
+
+const dependencies = [];
+
+const devDependencies = [
+    "awesome-typescript-loader",
+    "html-webpack-plugin",
+    "http-server",
+    "typescript",
+    "webpack",
+    "webpack-dev-server"
+];
+
+const parseParameters = parameters => ( {
+    dependencies: [
+        ...dependencies,
+        ...( parameters.prod || [] )
+    ],
+    devDependencies: [
+        ...devDependencies,
+        ...( parameters.dev || [] )
+    ]
+} );
+
+
+module.exports.parse = parseParameters;


### PR DESCRIPTION
Add parameters to specify dependencies and devDependencies while generating the seed.

## Syntax:

### Adding dependencies

The ```-d <dependency-name>``` switch adds a new dependency to the list, it can be repeated multiple times to add more than one dependency

```
ts-seed [name] -d dependency -d second-dependency
```
### Adding Dev dependencies

The ```-D <dependency-name>``` switch adds a new devDependency to the list, it can be repeated multiple times to add more than one devDependency

```
ts-seed [name] -D dependency -D second-dependency
```

### Mixing dependencies

Those switches can be used at the same time, so its possible to specify regular dependencies and devDependencies at the same time

```
ts-seed [name] -d dependency -D devDependency -d other-dependency
```

Fixes #2
